### PR TITLE
Fixed the bug of not being able to cu after a cu failure

### DIFF
--- a/config-update/main.lua
+++ b/config-update/main.lua
@@ -38,7 +38,7 @@ function main()
 
     print("New options values", options)
 
-    options["clean"] = true
+    options["check"] = true
 
     task.run("config", options)
 


### PR DESCRIPTION
After a failed cu, you are unable to use cu anymore because the options cache is cleaned. Changing the "clean" option to "check" can solve the problem.